### PR TITLE
Сhecking expired token

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -10,17 +10,11 @@ import { changeAuthStatus, changeUserData } from '../store/UserSlice';
 import { loginUser, getUserById } from '../services/APIrequests';
 import { decodeToken } from 'react-jwt';
 import { useLocaleMessage } from '../hooks';
+import { DecodedTokenProps } from '../types';
 
 interface AuthValue {
   userLogin: string;
   userPassword: string;
-}
-
-interface DecodedTokenProps {
-  id: string;
-  login: string;
-  iat: number;
-  exp: number;
 }
 
 const AuthPage: React.FC = () => {
@@ -31,16 +25,16 @@ const AuthPage: React.FC = () => {
   const message = useLocaleMessage();
 
   const onFinish = async (values: AuthValue) => {
-    console.log('Success:', values);
     const { userLogin, userPassword } = values;
 
     try {
       const { token } = await loginUser(userLogin, userPassword).then((res) => res.data);
-      const decodedToken = (await decodeToken(token)) as DecodedTokenProps;
+      const { id, exp } = (await decodeToken(token)) as DecodedTokenProps;
 
-      localStorage.setItem('idUser', decodedToken.id);
+      localStorage.setItem('idUser', id);
       localStorage.setItem('tokenUser', token);
       localStorage.setItem('loginUser', userLogin);
+      localStorage.setItem('expToken', String(exp));
 
       const { name } = await getUserById().then((res) => res.data);
 
@@ -48,7 +42,7 @@ const AuthPage: React.FC = () => {
         name,
         login: userLogin,
         password: userPassword,
-        id: decodedToken.id,
+        id,
       };
 
       dispatch(changeUserData(userData));

--- a/src/pages/WelcomePage.tsx
+++ b/src/pages/WelcomePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { BasePage } from '../components';
 import heroTeamIco from '../assets/ico/hero-img.svg';
@@ -7,9 +7,24 @@ import avatar2 from '../assets/ico/avatar-daria.png';
 import avatar3 from '../assets/ico/avatar-sergey.png';
 import avatar4 from '../assets/ico/avatar-denis.png';
 import { useLocaleMessage } from '../hooks';
+import checkTokenExpired from '../services/checkTokenExpired';
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '../store/Store';
+import { changeAuthStatus, removeUserData } from '../store/UserSlice';
 
 const WelcomePage: React.FC = () => {
   const message = useLocaleMessage();
+  const dispatch = useDispatch<AppDispatch>();
+
+  useEffect(() => {
+    const authStatus = checkTokenExpired();
+
+    if (!authStatus) {
+      dispatch(changeAuthStatus(false));
+      dispatch(removeUserData());
+      localStorage.clear();
+    }
+  }, [dispatch]);
 
   return (
     <BasePage>

--- a/src/services/checkTokenExpired.ts
+++ b/src/services/checkTokenExpired.ts
@@ -1,0 +1,11 @@
+const checkTokenExpired = () => {
+  const expTime = Number(localStorage.getItem('expToken'));
+  const currentTime = Math.floor(Date.now() / 1000);
+
+  if (currentTime > expTime) {
+    return false;
+  }
+  return true;
+};
+
+export default checkTokenExpired;

--- a/src/types/DecodedTokenProps.ts
+++ b/src/types/DecodedTokenProps.ts
@@ -1,0 +1,8 @@
+interface DecodedTokenProps {
+  id: string;
+  login: string;
+  iat: number;
+  exp: number;
+}
+
+export default DecodedTokenProps;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export type { default as InitialUserState } from './InitialUserState';
 export type { default as SingleBoardProps } from './SingleBoardProps';
 export type { default as InitialBoardsState } from './InitialBoardsState';
 export type { default as BoardResponse } from './BoardResponse';
+export type { default as DecodedTokenProps } from './DecodedTokenProps';


### PR DESCRIPTION
**Задача: по истечении времени действия токена разлогинить пользователя и отправить на страницу welcome.**

Наш токен действует около 12ч. Т.е. если пользователь долго работает и превысит норму 12ч, его должно разлогинить. Рефреш токена не предусмотрен, поэтому пользователь при авторизации со старыми логин/паролем получит новый токен на 12ч.

В папке /services создан checkTokenExpired.ts , который проверяет текущее время в сек с датой истечения токена (которая сохраняется в LS).

Проверка реализуется на 2х уровнях:
1) при маунте страниц /welcome, /editProfile, /boards через useEffect. Т.е. если пользователь начнет переходить по страничкам, сработает проверка токена. Если истек - разлогин.
2) если после 12ч пользователь не будет менять страницу, а захочет кинуть запрос, например, на создание борда, то перед запросом сработает проверка токена: если authStatus true - запрос пойдет, если false, разлогин.

**_PS: В самой таске по истекшему токену прописан пункт следующей формулировкой:
«When the token expires - the user should be redirected to the Welcome page automatically»_**

UPD: протестила фактически - оставила открытой страницу на ночь, по истечении 12ч перешла на другую страничку приложения - сработал logout

